### PR TITLE
Updated nokogiri because of Dependabot highlighting the CVE in < 1.10.8

### DIFF
--- a/wrstudios/frodata/Gemfile.lock
+++ b/wrstudios/frodata/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       nokogiri (~> 1.8)
     mini_portile2 (2.4.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
 
 PLATFORMS

--- a/wrstudios/frodata/README.md
+++ b/wrstudios/frodata/README.md
@@ -2,7 +2,7 @@
     apt install ruby-nokogiri
     apt install ruby2.5-dev
     apt install zlib1t-dev
-    gem install nokogiri -v '1.10.7'
+    gem install nokogiri -v '1.10.8'
     
     Then you can bundle install in the directory
 


### PR DESCRIPTION
Tested running on WSL